### PR TITLE
Drastically improve performance of ThresholdFinder

### DIFF
--- a/src/threshold_finder.cpp
+++ b/src/threshold_finder.cpp
@@ -44,6 +44,7 @@ ThresholdFinder::find_threshold(const std::function<std::unique_ptr<Lattice>()> 
     std::mt19937 rng(dev());
 
     std::vector<double> thresholds;
+    std::vector<size_t> path;
 
     for (size_t i = 0; i < iterations; ++i) {
         auto lat = generator();
@@ -55,6 +56,9 @@ ThresholdFinder::find_threshold(const std::function<std::unique_ptr<Lattice>()> 
 
         size_t dropped_count = 0;
         do {
+            // If it's the first iteration on a given lattice, path will be empty and it's necessary to compute it
+            bool path_interrupted = path.size() == 0;
+
             if (mode == EDGES) {
                 size_t edge_id, node_a, node_b;
                 bool settled = false;
@@ -72,6 +76,14 @@ ThresholdFinder::find_threshold(const std::function<std::unique_ptr<Lattice>()> 
                 } while (!settled);
 
                 lat->drop_edge_between(node_a, node_b);
+                if (path.size() > 0) {
+                    for (size_t k = 0; k < path.size() - 1; ++k) {
+                        if ((path[k] == node_a && path[k + 1] == node_b) || (path[k] == node_b && path[k + 1] == node_a)) {
+                            path_interrupted = true;
+                            break;
+                        }
+                    }
+                }
             } else if (mode == NODES) {
                 size_t node_id;
                 do {
@@ -79,42 +91,55 @@ ThresholdFinder::find_threshold(const std::function<std::unique_ptr<Lattice>()> 
                 } while (nodes[node_id].edges.empty());
 
                 lat->drop_node(node_id);
+                if (path.size() > 0) {
+                    for (size_t k = 0; k < path.size(); ++k) {
+                        if (path[k] == node_id) {
+                            path_interrupted = true;
+                            break;
+                        }
+                    }
+                }
             } else {
                 return Result();
             }
-
             ++dropped_count;
-        } while (is_permeable(*lat));
+
+            if (path_interrupted)
+                path = is_permeable(*lat);
+        } while (path.size() > 0);
         lat.reset(nullptr);
         thresholds.push_back(1 - dropped_count / double(total));
     }
     return Result(thresholds);
 }
 
-/* static */ bool ThresholdFinder::is_permeable(const Lattice &lat) {
+/* static */ std::vector<size_t> ThresholdFinder::is_permeable(const Lattice &lat) {
     auto source_nodes = lat.source_idx();
     std::deque<bool> visited(lat.nodes().size(), false);
+    std::vector<size_t> path;
 
     for (size_t node: source_nodes) {
-        if (!visited[node] && path_exists(lat, node, visited)) {
-            return true;
+        if (!visited[node] && path_exists(lat, node, visited, path) > 0) {
+            break;
         }
     }
 
-    return false;
+    return path;
 }
 
-/* static */ bool ThresholdFinder::path_exists(const Lattice &lat, const size_t &from, std::deque<bool> &visited) {
+/* static */ bool ThresholdFinder::path_exists(const Lattice &lat, const size_t &from, std::deque<bool> &visited, std::vector<size_t> &path) {
     auto node = lat.nodes()[from];
     visited[from] = true;
 
     if (node.type == Node::Type::TARGET) {
+        path.push_back(from);
         return true;
     }
 
     for (size_t &edge : node.edges) {
         size_t another_node = from == lat.edges()[edge].node_b ? lat.edges()[edge].node_a : lat.edges()[edge].node_b;
-        if (!visited[another_node] && path_exists(lat, another_node, visited)) {
+        if (!visited[another_node] && path_exists(lat, another_node, visited, path)) {
+            path.push_back(from);
             return true;
         }
     }

--- a/src/threshold_finder.h
+++ b/src/threshold_finder.h
@@ -34,9 +34,9 @@ public:
 private:
     static Result find_threshold(const std::function<std::unique_ptr<Lattice>()> &generator, size_t iterations, Mode mode);
 
-    static bool is_permeable(const Lattice &lat);
+    static std::vector<size_t> is_permeable(const Lattice &lat);
 
-    static bool path_exists(const Lattice &lat, const size_t &from, std::deque<bool> &visited);
+    static bool path_exists(const Lattice &lat, const size_t &from, std::deque<bool> &visited, std::vector<size_t> &path);
 };
 }
 


### PR DESCRIPTION
Now it stores path of the last iteration, and checks if it was
interrupted because of the last node or edge deletion.

I'm quite impressed :) Before this commit it took me ~30 minutes to find
percolation threshold of a 1000x1000 lattice, now it only takes 15
seconds (a 120-times increase!).